### PR TITLE
Export string-utils and guid-utils

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- added export string-utils `lib/string`
+- added export `lib/string` and `lib/guid`
 
 ## [0.3.0] - 2024-01-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- added export string-utils `lib/string`
+
 ## [0.3.0] - 2024-01-15
 
 - added `isNullOrEmpty`, `isNullOrWhitespace` and `capitalize` utility functions

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,3 +2,4 @@ export * from "./lib/date";
 export * from "./lib/enum";
 export * from "./lib/localStorage";
 export * from "./lib/string";
+export * from "./lib/guid";

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
 export * from "./lib/date";
 export * from "./lib/enum";
 export * from "./lib/localStorage";
+export * from "./lib/string";


### PR DESCRIPTION
expose "./lib/string" and "./lib/guid"