### PR TITLE
function validateGuid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `validateGuid` function to check whether a given string is a valid Guid
+
 ### dependabot: \#31 Bump ip from 1.1.8 to 1.1.9
 
 ## [0.4.0] - 2024-01-29

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `validateGuid` function to check whether a given string is a valid Guid
+- `isValidGuid` function to check whether a given string is a valid Guid
 
 ### dependabot: \#31 Bump ip from 1.1.8 to 1.1.9
 

--- a/src/lib/guid.spec.ts
+++ b/src/lib/guid.spec.ts
@@ -2,18 +2,27 @@ import { newGuid, emptyGuid, isValidGuid } from "./guid";
 
 describe("guid tests", () => {
   test("newGuid", () => {
-    expect(newGuid()).toMatch(/^[0-9a-fA-F]{8}-(?:[0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}$/);
+    expect(newGuid()).toMatch(/^[0-9a-ff-f]{8}-(?:[0-9a-ff-f]{4}-){3}[0-9a-ff-f]{12}$/);
   });
 
   test("emptyGuid", () => {
     expect(emptyGuid).toBe("00000000-0000-0000-0000-000000000000");
   });
 
-  test("isValidGuid", () => {
-    expect(isValidGuid(newGuid().toString())).toBeTruthy();
-    expect(isValidGuid("507956c7-30b3-4401-9800-e5e7f8f32761")).toBeTruthy();
-    expect(isValidGuid(emptyGuid)).toBeTruthy();
-    expect(isValidGuid("Im not a guid")).toBeFalsy();
-    expect(isValidGuid("507956c7-30b3-4401-9800-e5e7f8f3276")).toBeFalsy();
+  test.each([
+    [null as unknown as string, false],
+    [undefined as unknown as string, false],
+    [0 as unknown as string, false],
+    [10 as unknown as string, false],
+    [new Date() as unknown as string, false],
+    ["", false],
+    [" ", false],
+    ["507956c7-30b3-4401-9800-e5e7f8f3276X", false],
+    ["507956c7-30b3-4401-9800-e5e7f8f32761", true],
+    [newGuid(), true],
+    [emptyGuid, true],
+    ["3B467B14-CD99-4199-8E35-82B3C37182BA", true],
+  ])("isValidGuid", (value, expected) => {
+    expect(isValidGuid(value)).toBe(expected);
   });
 });

--- a/src/lib/guid.spec.ts
+++ b/src/lib/guid.spec.ts
@@ -1,4 +1,4 @@
-import { newGuid, emptyGuid, validateGuid } from "./guid";
+import { newGuid, emptyGuid, isValidGuid } from "./guid";
 
 describe("guid tests", () => {
   test("newGuid", () => {
@@ -9,10 +9,10 @@ describe("guid tests", () => {
     expect(emptyGuid).toBe("00000000-0000-0000-0000-000000000000");
   });
 
-  test("validateGuid", () => {
-    expect(validateGuid(newGuid().toString())).toBeTruthy();
-    expect(validateGuid("507956c7-30b3-4401-9800-e5e7f8f32761")).toBeTruthy();
-    expect(validateGuid("Im not a guid")).toBeFalsy();
-    expect(validateGuid("507956c7-30b3-4401-9800-e5e7f8f3276")).toBeFalsy();
+  test("isValidGuid", () => {
+    expect(isValidGuid(newGuid().toString())).toBeTruthy();
+    expect(isValidGuid("507956c7-30b3-4401-9800-e5e7f8f32761")).toBeTruthy();
+    expect(isValidGuid("Im not a guid")).toBeFalsy();
+    expect(isValidGuid("507956c7-30b3-4401-9800-e5e7f8f3276")).toBeFalsy();
   });
 });

--- a/src/lib/guid.spec.ts
+++ b/src/lib/guid.spec.ts
@@ -2,7 +2,7 @@ import { newGuid, emptyGuid, isValidGuid } from "./guid";
 
 describe("guid tests", () => {
   test("newGuid", () => {
-    expect(newGuid()).toMatch(/^[0-9a-ff-f]{8}-(?:[0-9a-ff-f]{4}-){3}[0-9a-ff-f]{12}$/);
+    expect(newGuid()).toMatch(/^[0-9a-fA-F]{8}-(?:[0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}$/);
   });
 
   test("emptyGuid", () => {
@@ -22,6 +22,8 @@ describe("guid tests", () => {
     [newGuid(), true],
     [emptyGuid, true],
     ["3B467B14-CD99-4199-8E35-82B3C37182BA", true],
+    // MAX not recognized as guid > https://github.com/uuidjs/uuid/pull/714
+    ["ffffffff-ffff-ffff-ffff-ffffffffffff", false],
   ])("isValidGuid", (value, expected) => {
     expect(isValidGuid(value)).toBe(expected);
   });

--- a/src/lib/guid.spec.ts
+++ b/src/lib/guid.spec.ts
@@ -1,4 +1,4 @@
-import { newGuid, emptyGuid } from "./guid";
+import { newGuid, emptyGuid, validateGuid } from "./guid";
 
 describe("guid tests", () => {
   test("newGuid", () => {
@@ -7,5 +7,12 @@ describe("guid tests", () => {
 
   test("emptyGuid", () => {
     expect(emptyGuid).toBe("00000000-0000-0000-0000-000000000000");
+  });
+
+  test("validateGuid", () => {
+    expect(validateGuid(newGuid().toString())).toBeTruthy();
+    expect(validateGuid("507956c7-30b3-4401-9800-e5e7f8f32761")).toBeTruthy();
+    expect(validateGuid("Im not a guid")).toBeFalsy();
+    expect(validateGuid("507956c7-30b3-4401-9800-e5e7f8f3276")).toBeFalsy();
   });
 });

--- a/src/lib/guid.spec.ts
+++ b/src/lib/guid.spec.ts
@@ -12,6 +12,7 @@ describe("guid tests", () => {
   test("isValidGuid", () => {
     expect(isValidGuid(newGuid().toString())).toBeTruthy();
     expect(isValidGuid("507956c7-30b3-4401-9800-e5e7f8f32761")).toBeTruthy();
+    expect(isValidGuid(emptyGuid)).toBeTruthy();
     expect(isValidGuid("Im not a guid")).toBeFalsy();
     expect(isValidGuid("507956c7-30b3-4401-9800-e5e7f8f3276")).toBeFalsy();
   });

--- a/src/lib/guid.ts
+++ b/src/lib/guid.ts
@@ -9,6 +9,15 @@ export function newGuid() {
 }
 
 /**
+ * Check whether a string it is a valid Guid (version 4 UUID)
+ * @param str The string to test whether it is a valid Guid
+ * @returns A value indicating whether the string is a valid Guid
+ */
+export function validateGuid(str: string) {
+  return uuid.validate(str);
+}
+
+/**
  * The empty Guid (an identifier containing all zeros)
  */
 export const emptyGuid = uuid.NIL;

--- a/src/lib/guid.ts
+++ b/src/lib/guid.ts
@@ -13,7 +13,7 @@ export function newGuid() {
  * @param str The string to test whether it is a valid Guid
  * @returns A value indicating whether the string is a valid Guid
  */
-export function validateGuid(str: string) {
+export function isValidGuid(str: string) {
   return uuid.validate(str);
 }
 


### PR DESCRIPTION
This PR implements a wrapper function `validateGuid` able to validate a string to check whether it is guid uuid v4.
Closes #34 